### PR TITLE
feat: add image processing filters for AI pipeline

### DIFF
--- a/app/service/AIService/data_processing/data_processor.py
+++ b/app/service/AIService/data_processing/data_processor.py
@@ -1,22 +1,27 @@
 from abc import ABC, abstractmethod
+from app.service.AIService.data_processing.filters.blur_filter import BlurFilter
+from app.service.AIService.data_processing.filters.brightness_filter import BrightnessFilter
+
 
 class BaseFilter(ABC):
 
     @abstractmethod
-    def verify_image(self, image)->bool:
+    def verify_image(self, image) -> bool:
         pass
 
     @abstractmethod
     def process_image(self, image):
         pass
 
+
 class FilterFactory:
     def __init__(self):
         self.filters = {
-            # blur_filter: BlurFilter
+            "blur_filter": BlurFilter,
+            "brightness_filter": BrightnessFilter,
         }
-    
-    def get_filter(self, filter_type:str)->BaseFilter:
+
+    def get_filter(self, filter_type: str) -> BaseFilter:
         if filter_type in self.filters:
             return self.filters[filter_type]
         else:

--- a/app/service/AIService/data_processing/data_processor.py
+++ b/app/service/AIService/data_processing/data_processor.py
@@ -1,6 +1,4 @@
 from abc import ABC, abstractmethod
-from app.service.AIService.data_processing.filters.blur_filter import BlurFilter
-from app.service.AIService.data_processing.filters.brightness_filter import BrightnessFilter
 
 
 class BaseFilter(ABC):
@@ -16,6 +14,9 @@ class BaseFilter(ABC):
 
 class FilterFactory:
     def __init__(self):
+        from app.service.AIService.data_processing.filters.blur_filter import BlurFilter
+        from app.service.AIService.data_processing.filters.brightness_filter import BrightnessFilter
+
         self.filters = {
             "blur_filter": BlurFilter,
             "brightness_filter": BrightnessFilter,
@@ -23,6 +24,6 @@ class FilterFactory:
 
     def get_filter(self, filter_type: str) -> BaseFilter:
         if filter_type in self.filters:
-            return self.filters[filter_type]
+            return self.filters[filter_type]()
         else:
-            raise ValueError("Invalid filter type")
+            raise ValueError(f"Invalid filter type: '{filter_type}'")

--- a/app/service/AIService/data_processing/filters/blur_filter.py
+++ b/app/service/AIService/data_processing/filters/blur_filter.py
@@ -11,7 +11,7 @@ class BlurFilter(BaseFilter):
     Blur cannot be fully fixed, but we attempt a sharpening pass once.
     """
 
-    BLUR_THRESHOLD = 80.0  # below this = too blurry
+    BLUR_THRESHOLD = 15.0
 
     def _measure_blur(self, image: np.ndarray) -> float:
         """Returns the Laplacian variance score. Higher = sharper."""

--- a/app/service/AIService/data_processing/filters/blur_filter.py
+++ b/app/service/AIService/data_processing/filters/blur_filter.py
@@ -1,0 +1,55 @@
+import cv2
+import numpy as np
+from app.service.AIService.data_processing.data_processor import BaseFilter
+
+
+class BlurFilter(BaseFilter):
+    """
+    Detects if an image is too blurry.
+    Uses Laplacian variance — sharp images have high variance,
+    blurry images have low variance.
+    Blur cannot be fully fixed, but we attempt a sharpening pass once.
+    """
+
+    BLUR_THRESHOLD = 80.0  # below this = too blurry
+
+    def _measure_blur(self, image: np.ndarray) -> float:
+        """Returns the Laplacian variance score. Higher = sharper."""
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        return cv2.Laplacian(gray, cv2.CV_64F).var()
+
+    def _sharpen(self, image: np.ndarray) -> np.ndarray:
+        """Applies an unsharp mask to try to recover some sharpness."""
+        kernel = np.array([
+            [0, -1,  0],
+            [-1,  5, -1],
+            [0, -1,  0]
+        ])
+        return cv2.filter2D(image, -1, kernel)
+
+    def verify_image(self, image: np.ndarray) -> bool:
+        score = self._measure_blur(image)
+        print(
+            f"[BlurFilter] Blur score: {score:.2f} (threshold: {self.BLUR_THRESHOLD})")
+        return score >= self.BLUR_THRESHOLD
+
+    def process_image(self, image: np.ndarray) -> np.ndarray:
+        # Step 1 — test
+        if self.verify_image(image):
+            print("[BlurFilter] PASS — image is sharp enough.")
+            return image
+
+        print("[BlurFilter] FAIL — image is blurry. Attempting sharpening fix...")
+
+        # Step 2 — fix
+        fixed = self._sharpen(image)
+
+        # Step 3 — retest
+        if self.verify_image(fixed):
+            print("[BlurFilter] PASS after fix — sharpening worked.")
+            return fixed
+
+        # Step 4 — reject
+        print("[BlurFilter] REJECT — image still too blurry after fix.")
+        raise ValueError(
+            "Image rejected: too blurry and could not be recovered.")

--- a/app/service/AIService/data_processing/filters/brightness_filter.py
+++ b/app/service/AIService/data_processing/filters/brightness_filter.py
@@ -1,0 +1,65 @@
+import cv2
+import numpy as np
+from app.service.AIService.data_processing.data_processor import BaseFilter
+
+
+class BrightnessFilter(BaseFilter):
+    """
+    Detects if an image is too dark or too bright.
+    Uses the mean pixel value of the grayscale image.
+    Attempts gamma correction as a fix.
+    """
+
+    MIN_BRIGHTNESS = 50   # below this = too dark
+    MAX_BRIGHTNESS = 220  # above this = too bright
+
+    def _measure_brightness(self, image: np.ndarray) -> float:
+        """Returns mean brightness (0-255). 0 = black, 255 = white."""
+        gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+        return float(np.mean(gray))
+
+    def _gamma_correction(self, image: np.ndarray, gamma: float) -> np.ndarray:
+        """
+        Gamma < 1 = darken, Gamma > 1 = brighten.
+        Builds a lookup table for fast per-pixel correction.
+        """
+        inv_gamma = 1.0 / gamma
+        table = np.array([
+            ((i / 255.0) ** inv_gamma) * 255
+            for i in range(256)
+        ], dtype=np.uint8)
+        return cv2.LUT(image, table)
+
+    def verify_image(self, image: np.ndarray) -> bool:
+        brightness = self._measure_brightness(image)
+        print(
+            f"[BrightnessFilter] Brightness: {brightness:.2f} (range: {self.MIN_BRIGHTNESS}-{self.MAX_BRIGHTNESS})")
+        return self.MIN_BRIGHTNESS <= brightness <= self.MAX_BRIGHTNESS
+
+    def process_image(self, image: np.ndarray) -> np.ndarray:
+        # Step 1 — test
+        if self.verify_image(image):
+            print("[BrightnessFilter] PASS — brightness is acceptable.")
+            return image
+
+        brightness = self._measure_brightness(image)
+        print(
+            f"[BrightnessFilter] FAIL — brightness out of range. Applying gamma correction...")
+
+        # Step 2 — fix
+        if brightness < self.MIN_BRIGHTNESS:
+            gamma = 2.0   # brighten
+        else:
+            gamma = 0.5   # darken
+
+        fixed = self._gamma_correction(image, gamma)
+
+        # Step 3 — retest
+        if self.verify_image(fixed):
+            print("[BrightnessFilter] PASS after fix — gamma correction worked.")
+            return fixed
+
+        # Step 4 — reject
+        print("[BrightnessFilter] REJECT — brightness still unacceptable after fix.")
+        raise ValueError(
+            "Image rejected: brightness out of range and could not be corrected.")

--- a/app/service/AIService/data_processing/filters/brightness_filter.py
+++ b/app/service/AIService/data_processing/filters/brightness_filter.py
@@ -10,7 +10,7 @@ class BrightnessFilter(BaseFilter):
     Attempts gamma correction as a fix.
     """
 
-    MIN_BRIGHTNESS = 50   # below this = too dark
+    MIN_BRIGHTNESS = 70   # below this = too dark
     MAX_BRIGHTNESS = 220  # above this = too bright
 
     def _measure_brightness(self, image: np.ndarray) -> float:


### PR DESCRIPTION
## Description
Implements 2 image processing filters that run before the face detection model.

Both filters follow the same logic:
> test → fix → retest → reject if still failing

## Filters Added

### BlurFilter
- Detects blur using Laplacian variance
- Attempts sharpening as a fix
- Rejects if still blurry after fix

### BrightnessFilter
- Detects too dark or too bright images using mean pixel value
- Applies gamma correction as a fix
- Rejects if still out of range after fix

## Notes
- Both filters inherit from `BaseFilter`
- Both are registered in `FilterFactory`
- Brightness check currently uses whole-image mean — can be improved later to target face region only

## Related Issue
Closes #5