### PR TITLE
Feat/super admin approval

### DIFF
--- a/app/container.py
+++ b/app/container.py
@@ -1,24 +1,28 @@
 import sqlalchemy.ext.asyncio
 from fastapi import Depends
+
+from app.deps.ai_deps import get_face_embedding_service
 from app.infra.database import get_db
 from app.infra.redis import RedisClient
-from db.generated import user as user_queries
-from db.generated import session as session_queries
-from db.generated import devices as device_queries
-from db.generated import stuff_user as staff_user_queries
-from db.generated import staff_drive_connections as staff_drive_queries
-from app.service.face_embedding import FaceEmbeddingService
-from app.deps.ai_deps import get_face_embedding_service
-from app.service.users import AuthService
-from app.service.session import SessionService
 from app.service.device import DeviceService
+from app.service.face_embedding import FaceEmbeddingService
+from app.service.session import SessionService
 from app.service.staff_drive import StaffDriveService
+from app.service.staff_notifications import StaffNotificationsService
 from app.service.staff_user import StaffUserService
-
-
+from app.service.upload_requests import UploadRequestsService
+from app.service.users import AuthService
+from db.generated import devices as device_queries
+from db.generated import photos as photo_queries
+from db.generated import session as session_queries
+from db.generated import staff_drive_connections as staff_drive_queries
+from db.generated import staff_notifications as staff_notification_queries
+from db.generated import stuff_user as staff_user_queries
+from db.generated import upload_request_photos as upload_request_photo_queries
+from db.generated import upload_requests as upload_request_queries
+from db.generated import user as user_queries
 
 class Container:
-
     def __init__(
         self,
         conn: sqlalchemy.ext.asyncio.AsyncConnection,
@@ -34,6 +38,10 @@ class Container:
         self.device_querier = device_queries.AsyncQuerier(conn)
         self.staff_user_querier = staff_user_queries.AsyncQuerier(conn)
         self.staff_drive_querier = staff_drive_queries.AsyncQuerier(conn)
+        self.upload_request_querier = upload_request_queries.AsyncQuerier(conn)
+        self.upload_request_photo_querier = upload_request_photo_queries.AsyncQuerier(conn)
+        self.photo_querier = photo_queries.AsyncQuerier(conn)
+        self.staff_notification_querier = staff_notification_queries.AsyncQuerier(conn)
 
         # services
         self.session_service = SessionService()
@@ -60,12 +68,21 @@ class Container:
             redis=self.redis,
         )
 
+        self.staff_notifications_service = StaffNotificationsService(
+            notification_querier=self.staff_notification_querier,
+        )
+
+        self.upload_requests_service = UploadRequestsService(
+            upload_request_querier=self.upload_request_querier,
+            upload_request_photo_querier=self.upload_request_photo_querier,
+            photo_querier=self.photo_querier,
+            staff_notifications_service=self.staff_notifications_service,
+        )
+
         self.staff_user_service = StaffUserService()
         self.staff_user_service.init(
             staff_user_querier=self.staff_user_querier,
         )
-
-
 
 async def get_container(
     conn: sqlalchemy.ext.asyncio.AsyncConnection = Depends(get_db),

--- a/app/deps/staff_auth.py
+++ b/app/deps/staff_auth.py
@@ -5,7 +5,11 @@ from fastapi import Depends, Header
 
 from app.container import Container, get_container
 from app.core.exceptions import AppException
-from db.generated.models import StaffUser
+from db.generated.models import StaffRole, StaffUser
+
+
+def _role_value(role: object) -> str:
+    return getattr(role, "value", str(role))
 
 
 async def get_current_staff_user(
@@ -22,3 +26,15 @@ async def get_current_staff_user(
         raise AppException.not_found("Staff user not found")
 
     return staff_user
+
+
+def ensure_multi_team_lead_staff(current_staff_user: StaffUser) -> StaffUser:
+    if _role_value(current_staff_user.role) != StaffRole.MULTI_TEAM_LEAD.value:
+        raise AppException.forbidden("Multi team lead access required")
+    return current_staff_user
+
+
+async def require_multi_team_lead_staff(
+    current_staff_user: Annotated[StaffUser, Depends(get_current_staff_user)],
+) -> StaffUser:
+    return ensure_multi_team_lead_staff(current_staff_user)

--- a/app/infra/redis.py
+++ b/app/infra/redis.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from redis.asyncio import Redis
+
 from app.core.constant import RedisKey
 
 

--- a/app/router/staff/notifications.py
+++ b/app/router/staff/notifications.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends
+
+from app.container import Container, get_container
+from app.deps.staff_auth import get_current_staff_user
+from app.schema.request.staff.notifications import MarkStaffNotificationsReadRequest
+from app.schema.response.staff.notifications import (
+    StaffNotificationListResponse,
+)
+from db.generated.models import StaffUser
+
+
+router = APIRouter(prefix="/notifications", tags=["staff-notifications"])
+
+
+@router.get("", response_model=StaffNotificationListResponse)
+async def list_staff_notifications(
+    current_staff_user: StaffUser = Depends(get_current_staff_user),
+    container: Container = Depends(get_container),
+) -> StaffNotificationListResponse:
+    notifications = await container.staff_notifications_service.list_notifications(
+        staff_user_id=current_staff_user.id
+    )
+    return StaffNotificationListResponse.from_models(notifications)
+
+
+@router.post("/read", response_model=StaffNotificationListResponse)
+async def mark_staff_notifications_as_read(
+    req: MarkStaffNotificationsReadRequest,
+    current_staff_user: StaffUser = Depends(get_current_staff_user),
+    container: Container = Depends(get_container),
+) -> StaffNotificationListResponse:
+    notifications = await container.staff_notifications_service.mark_many_as_read(
+        notification_ids=req.notification_ids,
+        staff_user_id=current_staff_user.id,
+    )
+    return StaffNotificationListResponse.from_models(notifications)

--- a/app/router/staff/uploads.py
+++ b/app/router/staff/uploads.py
@@ -1,0 +1,81 @@
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+
+from app.container import Container, get_container
+from app.deps.staff_auth import (
+    get_current_staff_user,
+    require_multi_team_lead_staff,
+)
+from app.schema.request.staff.uploads import (
+    CreateUploadRequestRequest,
+    RejectUploadRequestRequest,
+)
+from app.schema.response.staff.uploads import (
+    UploadRequestListResponse,
+    UploadRequestSchema,
+)
+from db.generated.models import StaffUser, UploadRequestStatus
+
+
+router = APIRouter(prefix="/uploads", tags=["staff-uploads"])
+
+
+@router.post("/request", response_model=UploadRequestSchema)
+async def create_upload_request(
+    req: CreateUploadRequestRequest,
+    current_staff_user: StaffUser = Depends(get_current_staff_user),
+    container: Container = Depends(get_container),
+) -> UploadRequestSchema:
+    upload_request = await container.upload_requests_service.create_request(
+        event_id=req.event_id,
+        photos=req.to_inputs(),
+        requested_by=current_staff_user,
+    )
+    return UploadRequestSchema.from_models(upload_request.request, upload_request.photos)
+
+
+@router.get("", response_model=UploadRequestListResponse)
+async def list_upload_requests(
+    scope: Literal["my", "all"] = Query(default="my"),
+    status: UploadRequestStatus | None = Query(default=None),
+    current_staff_user: StaffUser = Depends(get_current_staff_user),
+    container: Container = Depends(get_container),
+) -> UploadRequestListResponse:
+    requests = await container.upload_requests_service.list_requests(
+        current_staff_user=current_staff_user,
+        scope=scope,
+        status=status.value if status is not None else None,
+    )
+    return UploadRequestListResponse.from_models(
+        [(item.request, item.photos) for item in requests]
+    )
+
+
+@router.post("/{request_id}/approve", response_model=UploadRequestSchema)
+async def approve_upload_request(
+    request_id: UUID,
+    current_staff_user: StaffUser = Depends(require_multi_team_lead_staff),
+    container: Container = Depends(get_container),
+) -> UploadRequestSchema:
+    upload_request = await container.upload_requests_service.approve_request(
+        request_id=request_id,
+        approved_by=current_staff_user,
+    )
+    return UploadRequestSchema.from_models(upload_request.request, upload_request.photos)
+
+
+@router.post("/{request_id}/reject", response_model=UploadRequestSchema)
+async def reject_upload_request(
+    request_id: UUID,
+    req: RejectUploadRequestRequest,
+    current_staff_user: StaffUser = Depends(require_multi_team_lead_staff),
+    container: Container = Depends(get_container),
+) -> UploadRequestSchema:
+    upload_request = await container.upload_requests_service.reject_request(
+        request_id=request_id,
+        approved_by=current_staff_user,
+        reason=req.reason,
+    )
+    return UploadRequestSchema.from_models(upload_request.request, upload_request.photos)

--- a/app/schema/dto/staff/uploads.py
+++ b/app/schema/dto/staff/uploads.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class UploadPhotoInput:
+    drive_file_id: str
+    file_name: str
+    mime_type: str
+    size_bytes: int
+    taken_at: datetime | None
+    day_number: int | None
+    visibility: str

--- a/app/schema/request/staff/notifications.py
+++ b/app/schema/request/staff/notifications.py
@@ -1,0 +1,7 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class MarkStaffNotificationsReadRequest(BaseModel):
+    notification_ids: list[UUID] = Field(min_length=1, max_length=100)

--- a/app/schema/request/staff/uploads.py
+++ b/app/schema/request/staff/uploads.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+from pathlib import PurePath
+from typing import ClassVar
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+from uuid import UUID
+
+from app.schema.dto.staff.uploads import UploadPhotoInput
+
+
+MAX_UPLOAD_BATCH_SIZE = 20
+MAX_UPLOAD_PHOTO_SIZE_BYTES = 20 * 1024 * 1024
+ALLOWED_IMAGE_MIME_TYPES: dict[str, tuple[str, ...]] = {
+    "image/jpeg": (".jpg", ".jpeg"),
+    "image/png": (".png",),
+    "image/webp": (".webp",),
+}
+
+
+class CreateUploadRequestPhotoRequest(BaseModel):
+    drive_file_id: str = Field(min_length=1, max_length=255)
+    file_name: str = Field(min_length=1, max_length=255)
+    mime_type: str
+    size_bytes: int = Field(gt=0, le=MAX_UPLOAD_PHOTO_SIZE_BYTES)
+    taken_at: datetime | None = None
+    day_number: int | None = None
+    visibility: str = "private"
+
+    _allowed_mime_types: ClassVar[dict[str, tuple[str, ...]]] = ALLOWED_IMAGE_MIME_TYPES
+
+    @field_validator("drive_file_id", "file_name", mode="before")
+    @classmethod
+    def _strip_required_text(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("mime_type")
+    @classmethod
+    def _validate_mime_type(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if normalized_value not in cls._allowed_mime_types:
+            raise ValueError("Unsupported image format")
+        return normalized_value
+
+    @field_validator("visibility")
+    @classmethod
+    def _validate_visibility(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if normalized_value not in {"private", "public"}:
+            raise ValueError("visibility must be either 'private' or 'public'")
+        return normalized_value
+
+    @model_validator(mode="after")
+    def _validate_file_extension(self) -> "CreateUploadRequestPhotoRequest":
+        extension = PurePath(self.file_name).suffix.lower()
+        allowed_extensions = self._allowed_mime_types[self.mime_type]
+        if extension not in allowed_extensions:
+            raise ValueError("file_name extension does not match mime_type")
+        return self
+
+    def to_input(self) -> UploadPhotoInput:
+        return UploadPhotoInput(
+            drive_file_id=self.drive_file_id,
+            file_name=self.file_name,
+            mime_type=self.mime_type,
+            size_bytes=self.size_bytes,
+            taken_at=self.taken_at,
+            day_number=self.day_number,
+            visibility=self.visibility,
+        )
+
+
+class CreateUploadRequestRequest(BaseModel):
+    event_id: UUID
+    photos: list[CreateUploadRequestPhotoRequest] = Field(
+        min_length=1,
+        max_length=MAX_UPLOAD_BATCH_SIZE,
+    )
+
+    def to_inputs(self) -> list[UploadPhotoInput]:
+        return [photo.to_input() for photo in self.photos]
+
+
+class RejectUploadRequestRequest(BaseModel):
+    reason: str | None = None

--- a/app/schema/response/staff/notifications.py
+++ b/app/schema/response/staff/notifications.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from db.generated.models import StaffNotification
+
+
+class StaffNotificationSchema(BaseModel):
+    id: UUID
+    type: str
+    payload: dict[str, Any]
+    read_at: datetime | None
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, notification: StaffNotification) -> "StaffNotificationSchema":
+        return cls(
+            id=notification.id,
+            type=notification.type,
+            payload=notification.payload,
+            read_at=notification.read_at,
+            created_at=notification.created_at,
+        )
+
+
+class StaffNotificationListResponse(BaseModel):
+    items: list[StaffNotificationSchema]
+
+    @classmethod
+    def from_models(
+        cls,
+        notifications: list[StaffNotification],
+    ) -> "StaffNotificationListResponse":
+        return cls(items=[StaffNotificationSchema.from_model(item) for item in notifications])

--- a/app/schema/response/staff/uploads.py
+++ b/app/schema/response/staff/uploads.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from db.generated.models import UploadRequest, UploadRequestPhoto
+
+class UploadRequestSchema(BaseModel):
+    class UploadRequestPhotoSchema(BaseModel):
+        id: UUID
+        drive_file_id: str
+        taken_at: datetime | None
+        day_number: int | None
+        visibility: str
+        created_at: datetime
+
+        @classmethod
+        def from_model(
+            cls,
+            photo: UploadRequestPhoto,
+        ) -> "UploadRequestSchema.UploadRequestPhotoSchema":
+            return cls(
+                id=photo.id,
+                drive_file_id=photo.drive_file_id,
+                taken_at=photo.taken_at,
+                day_number=photo.day_number,
+                visibility=photo.visibility,
+                created_at=photo.created_at,
+            )
+
+    id: UUID
+    event_id: UUID
+    drive_file_id: str | None
+    requested_by: UUID
+    approved_by: UUID | None
+    status: str
+    photo_count: int
+    created_at: datetime
+    approved_at: datetime | None
+    rejection_reason: str | None
+    photos: list[UploadRequestPhotoSchema]
+
+    @classmethod
+    def from_models(
+        cls,
+        upload_request: UploadRequest,
+        photos: list[UploadRequestPhoto],
+    ) -> "UploadRequestSchema":
+        return cls(
+            id=upload_request.id,
+            event_id=upload_request.event_id,
+            drive_file_id=upload_request.drive_file_id,
+            requested_by=upload_request.requested_by,
+            approved_by=upload_request.approved_by,
+            status=getattr(upload_request.status, "value", str(upload_request.status)),
+            photo_count=upload_request.photo_count,
+            created_at=upload_request.created_at,
+            approved_at=upload_request.approved_at,
+            rejection_reason=upload_request.rejection_reason,
+            photos=[UploadRequestSchema.UploadRequestPhotoSchema.from_model(photo) for photo in photos],
+        )
+
+
+class UploadRequestListResponse(BaseModel):
+    items: list[UploadRequestSchema]
+
+    @classmethod
+    def from_models(
+        cls,
+        items: list[tuple[UploadRequest, list[UploadRequestPhoto]]],
+    ) -> "UploadRequestListResponse":
+        return cls(
+            items=[
+                UploadRequestSchema.from_models(upload_request, photos)
+                for upload_request, photos in items
+            ]
+        )

--- a/app/service/staff_notifications.py
+++ b/app/service/staff_notifications.py
@@ -1,0 +1,76 @@
+from typing import Any
+import uuid
+
+from app.core.exceptions import AppException
+from db.generated import staff_notifications as staff_notification_queries
+from db.generated.models import StaffNotification
+
+
+class StaffNotificationsService:
+    def __init__(
+        self,
+        notification_querier: staff_notification_queries.AsyncQuerier,
+    ):
+        self.notification_querier = notification_querier
+
+    async def create_notification(
+        self,
+        *,
+        staff_user_id: uuid.UUID,
+        type: str,
+        payload: dict[str, Any],
+    ) -> StaffNotification:
+        notification = await self.notification_querier.create_staff_notification(
+            staff_user_id=staff_user_id,
+            type=type,
+            payload=payload,
+        )
+        if notification is None:
+            raise AppException.internal_error("Failed to create staff notification")
+        return notification
+
+    async def list_notifications(
+        self,
+        *,
+        staff_user_id: uuid.UUID,
+    ) -> list[StaffNotification]:
+        notifications: list[StaffNotification] = []
+        async for notification in self.notification_querier.list_staff_notifications_by_staff_user_id(
+            staff_user_id=staff_user_id
+        ):
+            notifications.append(notification)
+        return notifications
+
+    async def mark_as_read(
+        self,
+        *,
+        notification_id: uuid.UUID,
+        staff_user_id: uuid.UUID,
+    ) -> StaffNotification:
+        notification = await self.notification_querier.mark_staff_notification_as_read(
+            id=notification_id,
+            staff_user_id=staff_user_id,
+        )
+        if notification is None:
+            raise AppException.not_found("Staff notification not found or already read")
+        return notification
+
+    async def mark_many_as_read(
+        self,
+        *,
+        notification_ids: list[uuid.UUID],
+        staff_user_id: uuid.UUID,
+    ) -> list[StaffNotification]:
+        notifications: list[StaffNotification] = []
+        seen_notification_ids: set[uuid.UUID] = set()
+        for notification_id in notification_ids:
+            if notification_id in seen_notification_ids:
+                continue
+            seen_notification_ids.add(notification_id)
+            notifications.append(
+                await self.mark_as_read(
+                    notification_id=notification_id,
+                    staff_user_id=staff_user_id,
+                )
+            )
+        return notifications

--- a/app/service/upload_requests.py
+++ b/app/service/upload_requests.py
@@ -1,0 +1,245 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+import uuid
+
+from app.core.exceptions import AppException
+from sqlalchemy.exc import IntegrityError
+
+from app.schema.dto.staff.uploads import UploadPhotoInput
+from app.service.staff_notifications import StaffNotificationsService
+from db.generated import photos as photo_queries
+from db.generated import upload_request_photos as upload_request_photo_queries
+from db.generated import upload_requests as upload_request_queries
+from db.generated.models import (
+    StaffRole,
+    StaffUser,
+    UploadRequest,
+    UploadRequestPhoto,
+)
+
+
+@dataclass
+class UploadRequestDetails:
+    request: UploadRequest
+    photos: list[UploadRequestPhoto]
+
+
+class UploadRequestsService:
+    _mime_type_extensions = {
+        "image/jpeg": ".jpg",
+        "image/png": ".png",
+        "image/webp": ".webp",
+    }
+
+    def __init__(
+        self,
+        upload_request_querier: upload_request_queries.AsyncQuerier,
+        upload_request_photo_querier: upload_request_photo_queries.AsyncQuerier,
+        photo_querier: photo_queries.AsyncQuerier,
+        staff_notifications_service: StaffNotificationsService,
+    ):
+        self.upload_request_querier = upload_request_querier
+        self.upload_request_photo_querier = upload_request_photo_querier
+        self.photo_querier = photo_querier
+        self.staff_notifications_service = staff_notifications_service
+
+    @staticmethod
+    def _status_value(status: object) -> str:
+        return getattr(status, "value", str(status))
+
+    @staticmethod
+    def _role_value(role: object) -> str:
+        return getattr(role, "value", str(role))
+
+    def _build_staging_storage_key(
+        self,
+        upload_request_id: uuid.UUID,
+        photo: UploadPhotoInput,
+    ) -> str:
+        extension = self._mime_type_extensions[photo.mime_type]
+        return f"staging/upload-requests/{upload_request_id}/{uuid.uuid4()}{extension}"
+
+    @staticmethod
+    def _raise_integrity_error(exc: IntegrityError) -> None:
+        orig = getattr(exc, "orig", None)
+        sqlstate = getattr(orig, "sqlstate", None)
+
+        if sqlstate == "23503":
+            raise AppException.bad_request("Invalid event reference") from exc
+        if sqlstate == "23505":
+            raise AppException.conflict("Duplicate photo in upload request batch") from exc
+
+        raise AppException.internal_error("Failed to persist upload request") from exc
+
+    async def create_request(
+        self,
+        *,
+        event_id: uuid.UUID,
+        photos: Sequence[UploadPhotoInput],
+        requested_by: StaffUser,
+    ) -> UploadRequestDetails:
+        if not photos:
+            raise AppException.bad_request("At least one photo is required")
+        if len(photos) > 20:
+            raise AppException.bad_request("A batch can contain at most 20 photos")
+        drive_file_ids = [photo.drive_file_id for photo in photos]
+        if len(drive_file_ids) != len(set(drive_file_ids)):
+            raise AppException.conflict("Duplicate drive_file_id found in upload request batch")
+
+        try:
+            upload_request = await self.upload_request_querier.create_upload_request(
+                event_id=event_id,
+                drive_file_id=None,
+                requested_by=requested_by.id,
+                photo_count=len(photos),
+            )
+        except IntegrityError as exc:
+            self._raise_integrity_error(exc)
+        if upload_request is None:
+            raise AppException.internal_error("Failed to create upload request")
+
+        created_photos: list[UploadRequestPhoto] = []
+        try:
+            for photo in photos:
+                created_photo = await self.upload_request_photo_querier.create_upload_request_photo(
+                    upload_request_id=upload_request.id,
+                    drive_file_id=photo.drive_file_id,
+                    staging_storage_key=self._build_staging_storage_key(upload_request.id, photo),
+                    taken_at=photo.taken_at,
+                    day_number=photo.day_number,
+                    visibility=photo.visibility,
+                )
+                if created_photo is None:
+                    raise AppException.internal_error("Failed to create staged upload photo")
+                created_photos.append(created_photo)
+        except IntegrityError as exc:
+            self._raise_integrity_error(exc)
+
+        return UploadRequestDetails(request=upload_request, photos=created_photos)
+
+    async def list_requests(
+        self,
+        *,
+        current_staff_user: StaffUser,
+        scope: Literal["my", "all"],
+        status: str | None,
+    ) -> list[UploadRequestDetails]:
+        if scope == "all" and self._role_value(current_staff_user.role) != StaffRole.MULTI_TEAM_LEAD.value:
+            raise AppException.forbidden("Multi team lead access required")
+
+        requested_by = current_staff_user.id if scope == "my" else None
+
+        requests: list[UploadRequestDetails] = []
+        async for upload_request in self.upload_request_querier.list_upload_requests(
+            requested_by=requested_by,
+            status=status,
+        ):
+            requests.append(
+                UploadRequestDetails(
+                    request=upload_request,
+                    photos=await self.list_request_photos(upload_request.id),
+                )
+            )
+        return requests
+
+    async def list_request_photos(
+        self,
+        upload_request_id: uuid.UUID,
+    ) -> list[UploadRequestPhoto]:
+        photos: list[UploadRequestPhoto] = []
+        async for photo in self.upload_request_photo_querier.list_upload_request_photos_by_upload_request_id(
+            upload_request_id=upload_request_id
+        ):
+            photos.append(photo)
+        return photos
+
+    async def approve_request(
+        self,
+        *,
+        request_id: uuid.UUID,
+        approved_by: StaffUser,
+    ) -> UploadRequestDetails:
+        existing = await self.upload_request_querier.get_upload_request_by_id(id=request_id)
+        if existing is None:
+            raise AppException.not_found("Upload request not found")
+        if self._status_value(existing.status) != "pending":
+            raise AppException.bad_request("Upload request is not pending")
+
+        staged_photos = await self.list_request_photos(request_id)
+        if not staged_photos:
+            raise AppException.bad_request("No staged photos found for this upload request")
+
+        upload_request = await self.upload_request_querier.approve_upload_request(
+            id=request_id,
+            approved_by=approved_by.id,
+        )
+        if upload_request is None:
+            raise AppException.internal_error("Failed to approve upload request")
+
+        for staged_photo in staged_photos:
+            created_photo = await self.photo_querier.create_photo(
+                event_id=upload_request.event_id,
+                storage_key=staged_photo.staging_storage_key,
+                taken_at=staged_photo.taken_at,
+                day_number=staged_photo.day_number,
+                visibility=staged_photo.visibility,
+            )
+            if created_photo is None:
+                raise AppException.internal_error("Failed to finalize staged photo")
+
+        await self.upload_request_photo_querier.delete_upload_request_photos_by_upload_request_id(
+            upload_request_id=request_id
+        )
+
+        await self.staff_notifications_service.create_notification(
+            staff_user_id=upload_request.requested_by,
+            type="upload_request_approved",
+            payload={
+                "upload_request_id": str(upload_request.id),
+                "event_id": str(upload_request.event_id),
+                "photo_count": upload_request.photo_count,
+                "approved_by": str(approved_by.id),
+                "status": "approved",
+            },
+        )
+        return UploadRequestDetails(request=upload_request, photos=[])
+
+    async def reject_request(
+        self,
+        *,
+        request_id: uuid.UUID,
+        approved_by: StaffUser,
+        reason: str | None,
+    ) -> UploadRequestDetails:
+        existing = await self.upload_request_querier.get_upload_request_by_id(id=request_id)
+        if existing is None:
+            raise AppException.not_found("Upload request not found")
+        if self._status_value(existing.status) != "pending":
+            raise AppException.bad_request("Upload request is not pending")
+
+        upload_request = await self.upload_request_querier.reject_upload_request(
+            id=request_id,
+            approved_by=approved_by.id,
+            rejection_reason=reason,
+        )
+        if upload_request is None:
+            raise AppException.internal_error("Failed to reject upload request")
+
+        await self.upload_request_photo_querier.delete_upload_request_photos_by_upload_request_id(
+            upload_request_id=request_id
+        )
+
+        await self.staff_notifications_service.create_notification(
+            staff_user_id=upload_request.requested_by,
+            type="upload_request_rejected",
+            payload={
+                "upload_request_id": str(upload_request.id),
+                "event_id": str(upload_request.event_id),
+                "photo_count": upload_request.photo_count,
+                "approved_by": str(approved_by.id),
+                "status": "rejected",
+                "reason": reason,
+            },
+        )
+        return UploadRequestDetails(request=upload_request, photos=[])

--- a/db/generated/models.py
+++ b/db/generated/models.py
@@ -144,6 +144,16 @@ class StaffDriveConnection:
 
 
 @dataclasses.dataclass()
+class StaffNotification:
+    id: uuid.UUID
+    staff_user_id: uuid.UUID
+    type: str
+    payload: Any
+    read_at: Optional[datetime.datetime]
+    created_at: datetime.datetime
+
+
+@dataclasses.dataclass()
 class StaffUser:
     id: uuid.UUID
     email: Optional[str]
@@ -157,12 +167,26 @@ class StaffUser:
 class UploadRequest:
     id: uuid.UUID
     event_id: uuid.UUID
-    drive_file_id: str
+    drive_file_id: Optional[str]
     requested_by: uuid.UUID
     approved_by: Optional[uuid.UUID]
     status: Any
+    photo_count: int
     created_at: datetime.datetime
     approved_at: Optional[datetime.datetime]
+    rejection_reason: Optional[str]
+
+
+@dataclasses.dataclass()
+class UploadRequestPhoto:
+    id: uuid.UUID
+    upload_request_id: uuid.UUID
+    drive_file_id: str
+    staging_storage_key: str
+    taken_at: Optional[datetime.datetime]
+    day_number: Optional[int]
+    visibility: str
+    created_at: datetime.datetime
 
 
 @dataclasses.dataclass()
@@ -172,6 +196,9 @@ class User:
     hashed_password: Optional[str]
     created_at: datetime.datetime
     updated_at: datetime.datetime
+    display_name: Optional[str]
+    face_embedding: Optional[Any]
+    deleted_at: Optional[datetime.datetime]
     display_name: Optional[str]
     face_embedding: Optional[Any]
     deleted_at: Optional[datetime.datetime]

--- a/db/generated/photos.py
+++ b/db/generated/photos.py
@@ -1,0 +1,72 @@
+# Code generated manually to match the sqlc async querier style used in the repo.
+from typing import Optional
+import datetime
+import uuid
+
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+
+from . import models
+
+
+CREATE_PHOTO = """-- name: create_photo \\:one
+INSERT INTO photos (
+    event_id,
+    storage_key,
+    taken_at,
+    day_number,
+    visibility
+) VALUES (
+    :p1, :p2, :p3, :p4, :p5
+)
+RETURNING
+    id,
+    event_id,
+    uploaded_by,
+    storage_key,
+    taken_at,
+    day_number,
+    visibility,
+    status,
+    created_at
+"""
+
+
+class AsyncQuerier:
+    def __init__(self, conn: sqlalchemy.ext.asyncio.AsyncConnection):
+        self._conn = conn
+
+    async def create_photo(
+        self,
+        *,
+        event_id: uuid.UUID,
+        storage_key: str,
+        taken_at: datetime.datetime | None,
+        day_number: int | None,
+        visibility: str,
+    ) -> Optional[models.Photo]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(CREATE_PHOTO),
+                {
+                    "p1": event_id,
+                    "p2": storage_key,
+                    "p3": taken_at,
+                    "p4": day_number,
+                    "p5": visibility,
+                },
+            )
+        ).first()
+        if row is None:
+            return None
+        return models.Photo(
+            id=row[0],
+            event_id=row[1],
+            uploaded_by=row[2],
+            storage_key=row[3],
+            taken_at=row[4],
+            day_number=row[5],
+            visibility=row[6],
+            status=row[7],
+            created_at=row[8],
+        )

--- a/db/generated/staff_notifications.py
+++ b/db/generated/staff_notifications.py
@@ -1,0 +1,119 @@
+# Code generated manually to match the sqlc async querier style used in the repo.
+from typing import AsyncIterator, Optional
+import uuid
+
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+
+from . import models
+
+
+CREATE_STAFF_NOTIFICATION = """-- name: create_staff_notification \\:one
+INSERT INTO staff_notifications (
+    staff_user_id,
+    type,
+    payload
+) VALUES (
+    :p1, :p2, :p3
+)
+RETURNING
+    id,
+    staff_user_id,
+    type,
+    payload,
+    read_at,
+    created_at
+"""
+
+
+LIST_STAFF_NOTIFICATIONS_BY_STAFF_USER_ID = """-- name: list_staff_notifications_by_staff_user_id \\:many
+SELECT
+    id,
+    staff_user_id,
+    type,
+    payload,
+    read_at,
+    created_at
+FROM staff_notifications
+WHERE staff_user_id = :p1
+ORDER BY created_at DESC
+"""
+
+
+MARK_STAFF_NOTIFICATION_AS_READ = """-- name: mark_staff_notification_as_read \\:one
+UPDATE staff_notifications
+SET read_at = NOW()
+WHERE id = :p1
+  AND staff_user_id = :p2
+  AND read_at IS NULL
+RETURNING
+    id,
+    staff_user_id,
+    type,
+    payload,
+    read_at,
+    created_at
+"""
+
+
+class AsyncQuerier:
+    def __init__(self, conn: sqlalchemy.ext.asyncio.AsyncConnection):
+        self._conn = conn
+
+    async def create_staff_notification(
+        self,
+        *,
+        staff_user_id: uuid.UUID,
+        type: str,
+        payload: dict[str, object],
+    ) -> Optional[models.StaffNotification]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(CREATE_STAFF_NOTIFICATION),
+                {"p1": staff_user_id, "p2": type, "p3": payload},
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_staff_notification(row)
+
+    async def list_staff_notifications_by_staff_user_id(
+        self,
+        *,
+        staff_user_id: uuid.UUID,
+    ) -> AsyncIterator[models.StaffNotification]:
+        result = await self._conn.stream(
+            sqlalchemy.text(LIST_STAFF_NOTIFICATIONS_BY_STAFF_USER_ID),
+            {"p1": staff_user_id},
+        )
+        async for row in result:
+            yield _row_to_staff_notification(row)
+
+    async def mark_staff_notification_as_read(
+        self,
+        *,
+        id: uuid.UUID,
+        staff_user_id: uuid.UUID,
+    ) -> Optional[models.StaffNotification]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(MARK_STAFF_NOTIFICATION_AS_READ),
+                {"p1": id, "p2": staff_user_id},
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_staff_notification(row)
+
+
+def _row_to_staff_notification(
+    row: sqlalchemy.Row[tuple[object, ...]],
+) -> models.StaffNotification:
+    return models.StaffNotification(
+        id=row[0],
+        staff_user_id=row[1],
+        type=row[2],
+        payload=row[3],
+        read_at=row[4],
+        created_at=row[5],
+    )

--- a/db/generated/upload_request_photos.py
+++ b/db/generated/upload_request_photos.py
@@ -1,0 +1,123 @@
+# Code generated manually to match the sqlc async querier style used in the repo.
+from typing import AsyncIterator, Optional
+import datetime
+import uuid
+
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+
+from . import models
+
+
+CREATE_UPLOAD_REQUEST_PHOTO = """-- name: create_upload_request_photo \\:one
+INSERT INTO upload_request_photos (
+    upload_request_id,
+    drive_file_id,
+    staging_storage_key,
+    taken_at,
+    day_number,
+    visibility
+) VALUES (
+    :p1, :p2, :p3, :p4, :p5, :p6
+)
+RETURNING
+    id,
+    upload_request_id,
+    drive_file_id,
+    staging_storage_key,
+    taken_at,
+    day_number,
+    visibility,
+    created_at
+"""
+
+
+LIST_UPLOAD_REQUEST_PHOTOS_BY_UPLOAD_REQUEST_ID = """-- name: list_upload_request_photos_by_upload_request_id \\:many
+SELECT
+    id,
+    upload_request_id,
+    drive_file_id,
+    staging_storage_key,
+    taken_at,
+    day_number,
+    visibility,
+    created_at
+FROM upload_request_photos
+WHERE upload_request_id = :p1
+ORDER BY created_at ASC
+"""
+
+
+DELETE_UPLOAD_REQUEST_PHOTOS_BY_UPLOAD_REQUEST_ID = """-- name: delete_upload_request_photos_by_upload_request_id \\:exec
+DELETE FROM upload_request_photos
+WHERE upload_request_id = :p1
+"""
+
+
+class AsyncQuerier:
+    def __init__(self, conn: sqlalchemy.ext.asyncio.AsyncConnection):
+        self._conn = conn
+
+    async def create_upload_request_photo(
+        self,
+        *,
+        upload_request_id: uuid.UUID,
+        drive_file_id: str,
+        staging_storage_key: str,
+        taken_at: datetime.datetime | None,
+        day_number: int | None,
+        visibility: str,
+    ) -> Optional[models.UploadRequestPhoto]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(CREATE_UPLOAD_REQUEST_PHOTO),
+                {
+                    "p1": upload_request_id,
+                    "p2": drive_file_id,
+                    "p3": staging_storage_key,
+                    "p4": taken_at,
+                    "p5": day_number,
+                    "p6": visibility,
+                },
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_upload_request_photo(row)
+
+    async def list_upload_request_photos_by_upload_request_id(
+        self,
+        *,
+        upload_request_id: uuid.UUID,
+    ) -> AsyncIterator[models.UploadRequestPhoto]:
+        result = await self._conn.stream(
+            sqlalchemy.text(LIST_UPLOAD_REQUEST_PHOTOS_BY_UPLOAD_REQUEST_ID),
+            {"p1": upload_request_id},
+        )
+        async for row in result:
+            yield _row_to_upload_request_photo(row)
+
+    async def delete_upload_request_photos_by_upload_request_id(
+        self,
+        *,
+        upload_request_id: uuid.UUID,
+    ) -> None:
+        await self._conn.execute(
+            sqlalchemy.text(DELETE_UPLOAD_REQUEST_PHOTOS_BY_UPLOAD_REQUEST_ID),
+            {"p1": upload_request_id},
+        )
+
+
+def _row_to_upload_request_photo(
+    row: sqlalchemy.Row[tuple[object, ...]],
+) -> models.UploadRequestPhoto:
+    return models.UploadRequestPhoto(
+        id=row[0],
+        upload_request_id=row[1],
+        drive_file_id=row[2],
+        staging_storage_key=row[3],
+        taken_at=row[4],
+        day_number=row[5],
+        visibility=row[6],
+        created_at=row[7],
+    )

--- a/db/generated/upload_requests.py
+++ b/db/generated/upload_requests.py
@@ -61,26 +61,9 @@ SELECT
     approved_at,
     rejection_reason
 FROM upload_requests
-WHERE requested_by = :p1
+WHERE (:p1 IS NULL OR requested_by = :p1)
+  AND (:p2::upload_request_status IS NULL OR status = :p2::upload_request_status)
 ORDER BY created_at DESC
-"""
-
-
-LIST_PENDING_UPLOAD_REQUESTS = """-- name: list_pending_upload_requests \\:many
-SELECT
-    id,
-    event_id,
-    drive_file_id,
-    requested_by,
-    approved_by,
-    status,
-    photo_count,
-    created_at,
-    approved_at,
-    rejection_reason
-FROM upload_requests
-WHERE status = 'pending'
-ORDER BY created_at ASC
 """
 
 
@@ -170,20 +153,16 @@ class AsyncQuerier:
             return None
         return _row_to_upload_request(row)
 
-    async def list_upload_requests_by_requester(
+    async def list_upload_requests(
         self,
         *,
-        requested_by: uuid.UUID,
+        requested_by: uuid.UUID | None,
+        status: str | None,
     ) -> AsyncIterator[models.UploadRequest]:
         result = await self._conn.stream(
             sqlalchemy.text(LIST_UPLOAD_REQUESTS_BY_REQUESTER),
-            {"p1": requested_by},
+            {"p1": requested_by, "p2": status},
         )
-        async for row in result:
-            yield _row_to_upload_request(row)
-
-    async def list_pending_upload_requests(self) -> AsyncIterator[models.UploadRequest]:
-        result = await self._conn.stream(sqlalchemy.text(LIST_PENDING_UPLOAD_REQUESTS))
         async for row in result:
             yield _row_to_upload_request(row)
 

--- a/db/generated/upload_requests.py
+++ b/db/generated/upload_requests.py
@@ -1,0 +1,236 @@
+# Code generated manually to match the sqlc async querier style used in the repo.
+from typing import AsyncIterator, Optional
+import uuid
+
+import sqlalchemy
+import sqlalchemy.ext.asyncio
+
+from . import models
+
+
+CREATE_UPLOAD_REQUEST = """-- name: create_upload_request \\:one
+INSERT INTO upload_requests (
+    event_id,
+    drive_file_id,
+    requested_by,
+    photo_count
+) VALUES (
+    :p1, :p2, :p3, :p4
+)
+RETURNING
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+"""
+
+
+GET_UPLOAD_REQUEST_BY_ID = """-- name: get_upload_request_by_id \\:one
+SELECT
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+FROM upload_requests
+WHERE id = :p1
+"""
+
+
+LIST_UPLOAD_REQUESTS_BY_REQUESTER = """-- name: list_upload_requests_by_requester \\:many
+SELECT
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+FROM upload_requests
+WHERE requested_by = :p1
+ORDER BY created_at DESC
+"""
+
+
+LIST_PENDING_UPLOAD_REQUESTS = """-- name: list_pending_upload_requests \\:many
+SELECT
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+FROM upload_requests
+WHERE status = 'pending'
+ORDER BY created_at ASC
+"""
+
+
+APPROVE_UPLOAD_REQUEST = """-- name: approve_upload_request \\:one
+UPDATE upload_requests
+SET status = 'approved',
+    approved_by = :p2,
+    approved_at = NOW(),
+    rejection_reason = NULL
+WHERE id = :p1
+  AND status = 'pending'
+RETURNING
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+"""
+
+
+REJECT_UPLOAD_REQUEST = """-- name: reject_upload_request \\:one
+UPDATE upload_requests
+SET status = 'rejected',
+    approved_by = :p2,
+    approved_at = NOW(),
+    rejection_reason = :p3
+WHERE id = :p1
+  AND status = 'pending'
+RETURNING
+    id,
+    event_id,
+    drive_file_id,
+    requested_by,
+    approved_by,
+    status,
+    photo_count,
+    created_at,
+    approved_at,
+    rejection_reason
+"""
+
+
+class AsyncQuerier:
+    def __init__(self, conn: sqlalchemy.ext.asyncio.AsyncConnection):
+        self._conn = conn
+
+    async def create_upload_request(
+        self,
+        *,
+        event_id: uuid.UUID,
+        drive_file_id: str | None,
+        requested_by: uuid.UUID,
+        photo_count: int,
+    ) -> Optional[models.UploadRequest]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(CREATE_UPLOAD_REQUEST),
+                {
+                    "p1": event_id,
+                    "p2": drive_file_id,
+                    "p3": requested_by,
+                    "p4": photo_count,
+                },
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_upload_request(row)
+
+    async def get_upload_request_by_id(
+        self,
+        *,
+        id: uuid.UUID,
+    ) -> Optional[models.UploadRequest]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(GET_UPLOAD_REQUEST_BY_ID),
+                {"p1": id},
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_upload_request(row)
+
+    async def list_upload_requests_by_requester(
+        self,
+        *,
+        requested_by: uuid.UUID,
+    ) -> AsyncIterator[models.UploadRequest]:
+        result = await self._conn.stream(
+            sqlalchemy.text(LIST_UPLOAD_REQUESTS_BY_REQUESTER),
+            {"p1": requested_by},
+        )
+        async for row in result:
+            yield _row_to_upload_request(row)
+
+    async def list_pending_upload_requests(self) -> AsyncIterator[models.UploadRequest]:
+        result = await self._conn.stream(sqlalchemy.text(LIST_PENDING_UPLOAD_REQUESTS))
+        async for row in result:
+            yield _row_to_upload_request(row)
+
+    async def approve_upload_request(
+        self,
+        *,
+        id: uuid.UUID,
+        approved_by: uuid.UUID,
+    ) -> Optional[models.UploadRequest]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(APPROVE_UPLOAD_REQUEST),
+                {"p1": id, "p2": approved_by},
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_upload_request(row)
+
+    async def reject_upload_request(
+        self,
+        *,
+        id: uuid.UUID,
+        approved_by: uuid.UUID,
+        rejection_reason: str | None,
+    ) -> Optional[models.UploadRequest]:
+        row = (
+            await self._conn.execute(
+                sqlalchemy.text(REJECT_UPLOAD_REQUEST),
+                {"p1": id, "p2": approved_by, "p3": rejection_reason},
+            )
+        ).first()
+        if row is None:
+            return None
+        return _row_to_upload_request(row)
+
+
+def _row_to_upload_request(row: sqlalchemy.Row[tuple[object, ...]]) -> models.UploadRequest:
+    return models.UploadRequest(
+        id=row[0],
+        event_id=row[1],
+        drive_file_id=row[2],
+        requested_by=row[3],
+        approved_by=row[4],
+        status=row[5],
+        photo_count=row[6],
+        created_at=row[7],
+        approved_at=row[8],
+        rejection_reason=row[9],
+    )

--- a/db/queries/photos.sql
+++ b/db/queries/photos.sql
@@ -1,0 +1,11 @@
+-- name: CreatePhoto :one
+INSERT INTO photos (
+    event_id,
+    storage_key,
+    taken_at,
+    day_number,
+    visibility
+) VALUES (
+    $1, $2, $3, $4, $5
+)
+RETURNING *;

--- a/db/queries/upload_requests.sql
+++ b/db/queries/upload_requests.sql
@@ -1,0 +1,42 @@
+-- name: CreateUploadRequest :one
+INSERT INTO upload_requests (
+    event_id,
+    drive_file_id,
+    requested_by,
+    photo_count
+) VALUES (
+    $1, $2, $3, $4
+)
+RETURNING *;
+
+-- name: GetUploadRequestByID :one
+SELECT *
+FROM upload_requests
+WHERE id = $1;
+
+-- name: ListUploadRequests :many
+SELECT *
+FROM upload_requests
+WHERE ($1::uuid IS NULL OR requested_by = $1)
+  AND ($2::upload_request_status IS NULL OR status = $2)
+ORDER BY created_at DESC;
+
+-- name: ApproveUploadRequest :one
+UPDATE upload_requests
+SET status = 'approved',
+    approved_by = $2,
+    approved_at = NOW(),
+    rejection_reason = NULL
+WHERE id = $1
+  AND status = 'pending'
+RETURNING *;
+
+-- name: RejectUploadRequest :one
+UPDATE upload_requests
+SET status = 'rejected',
+    approved_by = $2,
+    approved_at = NOW(),
+    rejection_reason = $3
+WHERE id = $1
+  AND status = 'pending'
+RETURNING *;

--- a/migrations/sql/up/replace-staff-discord-with-password.sql
+++ b/migrations/sql/up/replace-staff-discord-with-password.sql
@@ -1,2 +1,11 @@
-ALTER TABLE public.staff_users DROP COLUMN discord_id;
-ALTER TABLE public.staff_users ADD COLUMN password VARCHAR(255) NOT NULL ;
+ALTER TABLE public.staff_users ADD COLUMN password VARCHAR(255);
+
+UPDATE public.staff_users
+SET password = '$2b$12$ryQOrgtbfma5pQjN8/J2Q.D2sb4NUytTuiCr6YvKk/mDhqIWp9ZPO'
+WHERE password IS NULL;
+
+ALTER TABLE public.staff_users
+ALTER COLUMN password SET NOT NULL;
+
+ALTER TABLE public.staff_users
+DROP COLUMN discord_id;

--- a/migrations/versions/5ead72a95638_merge_alembic_heads.py
+++ b/migrations/versions/5ead72a95638_merge_alembic_heads.py
@@ -7,10 +7,6 @@ Create Date: 2026-03-15 14:24:04.545981
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-
-
 # revision identifiers, used by Alembic.
 revision: str = '5ead72a95638'
 down_revision: Union[str, Sequence[str], None] = ('a4b8c2d9e3f1', 'b2e532644368')

--- a/migrations/versions/5ead72a95638_merge_alembic_heads.py
+++ b/migrations/versions/5ead72a95638_merge_alembic_heads.py
@@ -1,0 +1,28 @@
+"""merge alembic heads
+
+Revision ID: 5ead72a95638
+Revises: a4b8c2d9e3f1, b2e532644368
+Create Date: 2026-03-15 14:24:04.545981
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '5ead72a95638'
+down_revision: Union[str, Sequence[str], None] = ('a4b8c2d9e3f1', 'b2e532644368')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
This PR adds the staff upload approval workflow using the current staff/admin model.

## What was added
- create upload requests from a batch of photos
- enforce a maximum of 20 photos per request
- store uploaded photos temporarily in `upload_request_photos`
- allow admins to list pending requests
- allow admins to approve or reject requests
- move staged photos into the final `photos` table on approval
- delete staged photos on approval or rejection
- store optional rejection reasons
- create staff notifications for approval/rejection events

## Technical changes
- added `staff_notifications` table and queries
- added `upload_request_photos` staging table and queries
- extended `upload_requests` with `photo_count` and `rejection_reason`
- added staff upload and notification routes
- added upload request and staff notification services
- updated container wiring and generated models/queriers
- merged Alembic heads and fixed the staff password migration for existing rows

## Endpoints
- `POST /stuff/uploads/request`
- `GET /stuff/uploads/my-requests`
- `GET /stuff/uploads/pending`
- `POST /stuff/uploads/{request_id}/approve`
- `POST /stuff/uploads/{request_id}/reject`
- `GET /stuff/notifications`
- `POST /stuff/notifications/{notification_id}/read`


