### PR TITLE
Fix/remove redundant face detection

### DIFF
--- a/app/service/face_embedding.py
+++ b/app/service/face_embedding.py
@@ -123,7 +123,28 @@ class FaceEmbeddingService:
 
         embeddings: list[np.ndarray] = []
 
+        for payload in payloads:
+            image = self._decode_image(payload)
+            image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
+            # Single detection pass — model.get() already returns embeddings
+            faces: list[FaceStub] = await asyncio.to_thread(
+                self.face_embedding.model.get, image_rgb  # type: ignore
+            )
+
+            if not faces:
+                raise AppException.bad_request(
+                    f"No faces detected in image {payload['filename']}"
+                )
+
+            face = faces[0]
+
+            if face.embedding is None:
+                raise AppException.bad_request(
+                    f"Failed to generate embedding for {payload['filename']}"
+                )
+
+            embeddings.append(face.embedding.astype(np.float32))
 
         stacked = np.stack(embeddings, axis=0)
         averaged = np.mean(stacked, axis=0)

--- a/app/service/face_embedding.py
+++ b/app/service/face_embedding.py
@@ -123,44 +123,7 @@ class FaceEmbeddingService:
 
         embeddings: list[np.ndarray] = []
 
-        for payload in payloads:
 
-            image = self._decode_image(payload)
-
-            if (
-                self.face_embedding.model is None
-                or not self.face_embedding._initialized # type: ignore
-            ):
-                raise RuntimeError("Face embedding model not ready")
-
-            image_rgb = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-
-            faces: list[FaceStub] = self.face_embedding.model.get(image_rgb)  # type: ignore
-
-            if not faces:
-                raise AppException.bad_request(
-                    f"No faces detected in image {payload['filename']}"
-                )
-
-            bboxes: list[BBox] = []
-
-            for face in faces:
-                fx1, fy1, fx2, fy2 = face.bbox
-                bboxes.append((int(fx1), int(fy1), int(fx2), int(fy2)))
-
-            try:
-                embedding = await asyncio.to_thread(
-                    self.face_embedding.embed,
-                    image,
-                    bboxes,
-                )
-
-            except (ValueError, RuntimeError) as exc:
-                raise AppException.bad_request(
-                    f"Face embedding failed for {payload['filename']}: {exc}"
-                ) from exc
-
-            embeddings.append(np.array(embedding, dtype=np.float32))
 
         stacked = np.stack(embeddings, axis=0)
         averaged = np.mean(stacked, axis=0)


### PR DESCRIPTION
## Summary
`compute_average_embedding()` was calling `model.get()` twice on the same image, once to extract bboxes, then again inside `embed()` via a thread. Since `model.get()` already returns face.embedding in the first call, the second detection pass was redundant and doubled the compute unnecessarily.
## Changes
- Removed bbox extraction loop and `embed()` call from `compute_average_embedding()`
- Moved `model.get()` into `asyncio.to_thread()` where the CPU-heavy work belongs
- Used `faces[0].embedding` directly from the single detection pass