### PR TITLE
chore: disable API docs in production

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -89,6 +89,9 @@ app = FastAPI(
     description="Mobile and Web API for multAI",
     version="1.0.0",
     lifespan=lifespan,
+    docs_url="/docs" if settings.debug else None,
+    redoc_url="/redoc" if settings.debug else None,
+    openapi_url="/openapi.json" if settings.debug else None,
 )
 
 


### PR DESCRIPTION
Hides /docs, /redoc, and /openapi.json when `debug=False` (i.e. production env).